### PR TITLE
Preserve pytest failures through tee

### DIFF
--- a/.github/workflows/test-pytest.yml
+++ b/.github/workflows/test-pytest.yml
@@ -65,6 +65,7 @@ jobs:
         env:
           PYTHONDONTWRITEBYTECODE: 1
         run: |
+          set -o pipefail
           python --version
           python -m pytest \
             -qq \


### PR DESCRIPTION
Enable pipefail before piping pytest output through tee. Failed tests currently produce a successful reusable workflow result because tee exits successfully.